### PR TITLE
CI: enable API compatibility check (pidiff)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
     env: TOX_ENV=py37
   - python: "3.7"
     env: TOX_ENV=pycodestyle
-  #- python: "3.7"
-  # env: TOX_ENV=pidiff
+  - python: "3.7.9"
+    env: TOX_ENV=pidiff
   - python: "3.7"
     env: TOX_ENV=cov-travis DEPLOY=1
   - python: "3.7"


### PR DESCRIPTION
iiblib is used in production and backwards-incompatible API
changes have the potential to break downstream projects such as
pubtools-iib and pub. As such, those changes should be discouraged,
so let's start testing for them.

The pidiff tool will not block API changes, but it will require them
to be given due consideration. Once the project version has reached
1.0.0, any API changes must be accompanied with an update to the
version number which abides by SemVer. PRs which change the API
will fail CI unless this is done.

Note this is a minor workflow change, as version number changes must
now happen along with API changes rather than happening just before
release (i.e. the version in setup.py will generally be equal to
the *next* release rather than the *last* release).

In practice the appropriate response to a CI failure here is
expected often to be not "I'll bump the version number" but
instead "I didn't realize I was making a backwards-incompatible
change; let's not do that".

Note: it's necessary to pick a specific Python 3.7 version here
because the default, 3.7.1, has a bug
https://bugs.python.org/issue34921 which happens to break pidiff.