### PR TITLE
Make version 1.0.0 to indicate stable release

### DIFF
--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - N/A
 
+## [1.0.0] - 2020-10-20
+
+### Changed
+ - Version set to 1.0.0 to indicate stable release
+
 ## [0.13.0] - 2020-10-14
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def read_content(filepath):
 
 
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python",
@@ -62,7 +62,7 @@ if os.environ.get("READTHEDOCS", None):
 
 setup(
     name="iiblib",
-    version="0.13.0",
+    version="1.0.0",
     description="IIB client library",
     long_description=long_description,
     author="Jindrich Luza",


### PR DESCRIPTION
This project has already been used in production for some time,
so backwards-compatibility is already important. The project
also claims to follow semver, but semver doesn't have any impact
until version 1.0.0.  Per [1], "If your software is being used in
production, it should probably already be 1.0.0."

"Used by production service" and "this project is alpha,
version 0.x and we can change anything at any time" are not
compatible; it is time to take stability seriously. Mark the
version as 1.0.0 accordingly.

[1] https://semver.org/spec/v2.0.0.html