### PR TITLE
Fix & re-nominate CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@midnightercz @jayz12138 @chandwatulsi
+*  @midnightercz @lipoja @querti


### PR DESCRIPTION
This repo had a CODEOWNERS file, but it never worked since it didn't
use the correct syntax. Let's make it work and also revise the list
of owners according to actual contributors (new nominated owners are
the top 3 committers).