### PR TITLE
docs: fix weird formatting in changelog

### DIFF
--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -5,22 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 - N/A
 
-## [1.0.0] - 2020-10-20
+## 1.0.0 - 2020-10-20
 
 ### Changed
  - Version set to 1.0.0 to indicate stable release
 
-## [0.13.0] - 2020-10-14
+## 0.13.0 - 2020-10-14
 
 ### Changed
  - Rename file iibclient.py to iib_client.py
  - Create new files for classes from iib_client.py
 
-## [0.12.0] - 2020-09-29
+## 0.12.0 - 2020-09-29
 
 ### Added
 
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - 'bundles' is now an optional parameter in IIB requests
  - 'binary_image' is now an optional parameter in IIB requests
 
-## [0.11.0] - 2020-07-06
+## 0.11.0 - 2020-07-06
 
 ### Added
 
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - retry is now triggered for all 5xx HTTP status codes (500-511)
 
-## [0.10.0] - 2020-06-25
+## 0.10.0 - 2020-06-25
 
 ### Fixed
 
@@ -57,13 +57,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - password-based auth to token by replacing content-delivery-release-bot
 
-## [0.9.0] - 2020-03-30
+## 0.9.0 - 2020-03-30
 
 ### Added
 
 - added overwrite_from_index param support
 
-## [0.8.0] - 2020-03-04
+## 0.8.0 - 2020-03-04
 
 ### Changed
 
@@ -73,44 +73,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - to_dict method for IIBBuildDetailsModel
 
-## [0.7.0] - 2020-03-04
+## 0.7.0 - 2020-03-04
 
 ### Fixed
 
 - rhel 6 compatibility kerberos fixes
 
-## [0.6.0] - 2020-03-01
+## 0.6.0 - 2020-03-01
 
 ### Fixed
 
 - requests-gssapi replaced with requests-kerberos
 
-## [0.5.0] - 2020-02-29
+## 0.5.0 - 2020-02-29
 
 ### Fixed
 
 - kerberos auth fixed
 
-## [0.4.0] - 2020-02-27
+## 0.4.0 - 2020-02-27
 
 ### Fixed
 
 - make client compatible with upstream IIB
 
-## [0.3.0] - 2020-02-27
+## 0.3.0 - 2020-02-27
 
 ### Fixed
 
 - Fixed kerberos auth
 - added way how to configure insecure ssl connection to IIB
 
-## [0.2.0] - 2020-02-26
+## 0.2.0 - 2020-02-26
 
 ### Fixed
 
 - Fixed incompatibilities with IIB
 
-## [0.1.0] - 2020-02-21
+## 0.1.0 - 2020-02-21
 
 ### Added
 - First iiblib release with support of basic IIB operations


### PR DESCRIPTION
In this format of changelog, the purpose of the [brackets] around
version numbers is that they'll be rendered as hyperlinks; see
for example another project using this format at [1].

However, this only works if you define the targets of the hyperlinks
(e.g. at end of the file). Since this was not done for iiblib's
changelog, the versions don't render as hyperlinks and the brackets
just make the log look more noisy - so let's not do that.

[1] https://github.com/release-engineering/pushsource/blob/master/CHANGELOG.md