### PR TITLE
Fix crash with Python 2.6

### DIFF
--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
- - N/A
+### Fixed
+
+ - fixed a Python 2.6 compatibility issue in iib_build_details_model
 
 ## 2.0.0 - 2020-11-19
 

--- a/iiblib/iib_build_details_model.py
+++ b/iiblib/iib_build_details_model.py
@@ -111,10 +111,10 @@ class IIBBuildDetailsModel(object):
             RegenerateBundleModel) and return the object
         """
 
-        request_types_and_classes = {
-            sub_cls._accepted_request_type: sub_cls
-            for sub_cls in IIBBuildDetailsModel.__subclasses__()
-        }
+        request_types_and_classes = {}
+        for sub_cls in IIBBuildDetailsModel.__subclasses__():
+            request_types_and_classes[sub_cls._accepted_request_type] = sub_cls
+
         cls._validate_data(request_types_and_classes, data)
 
         return request_types_and_classes[data["request_type"]](**data)


### PR DESCRIPTION
Despite what the README says, Python 2.6 is one of the target
platforms for this project; dict comprehensions can't be used
with that Python version.