### PR TITLE
Add RecursiveRelatedBundlesModel

### DIFF
--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+ - Added RecursiveRelatedBundlesModel 
 
 ## 6.0.0 - 2022-06-20
 

--- a/iiblib/iib_build_details_model.py
+++ b/iiblib/iib_build_details_model.py
@@ -490,3 +490,38 @@ class CreateEmptyIndexModel(IIBBuildDetailsModel):
     ]
 
     _accepted_request_type = "create-empty-index"
+
+
+class RecursiveRelatedBundlesModel(IIBBuildDetailsModel):
+    """
+    RecursiveRelatedBundles class handling data from "builds/recursive-related-bundles" endpoint,
+    and data from "builds" and "builds/<id>" IIB endpoints defined by
+    "recursive-related-bundles" request_type .
+    RecursiveRelatedBundles class inherits arguments from IIBBuildDetailsModel.
+    For a complete list of arguments check IIBBuildDetailsModel.
+
+    Args:
+        nested_bundles (list)
+            A list of nested bundles
+        organization (str)
+            A name of organization to push to in the legacy app registry
+        parent_bundle_image (str)
+            A reference of parent bundle image
+        parent_bundle_image_resolved (str)
+            A checksum reference of parent bundle image
+    """
+
+    __slots__ = [
+        "nested_bundles",
+        "organization",
+        "parent_bundle_image",
+        "parent_bundle_image_resolved",
+    ]
+    _operation_attrs = [
+        "nested_bundles",
+        "organization",
+        "parent_bundle_image",
+        "parent_bundle_image_resolved",
+    ]
+
+    _accepted_request_type = "recursive-related-bundles"

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ deps=
 commands = coverage report --fail-under 98
 
 [testenv:cov-travis]
-passenv = TRAVIS TRAVIS_*
+passenv = TRAVIS,TRAVIS_*
 deps=
     {[py]deps}
     pytest-cov


### PR DESCRIPTION
RecursiveRelatedBundlesModel is created, along with responding tests.

This is related to fixing iib-api-test.
There is an error during executing IIBBuildDetailsModel:_validate_data().
```
if data["request_type"] not in request_types_and_models:
           raise KeyError("Unsupported request type: %s" % data["request_type"])
          KeyError: 'Unsupported request type: recursive-related-bundles'
```

for example here: https://master-jenkins-csb-distribution.apps.ocp-c1.prod.psi.redhat.com/job/iib-api-test/671/console 
