### PR TITLE
Drop Python2 support

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -3,22 +3,6 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py27:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Update existing dependencies
-        run: sudo apt-get update -y
-      - name: Install system dependencies
-        run: sudo apt-get install -y libkrb5-dev
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 2.7
-      - name: Install Tox
-        run: pip install tox
-      - name: Run Tox
-        run: tox -e py27
   py37:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Requirements
 ------------
 
 * Python 3.7 over
-* Python 2.7 over
 
 Setup
 -----

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -53,7 +51,7 @@ long_description = read_content("README.md") + read_content(
     os.path.join("docs/source", "CHANGELOG.md")
 )
 
-INSTALL_REQUIRES = ["requests", "requests-kerberos", "six", "kerberos", "tenacity"]
+INSTALL_REQUIRES = ["requests", "requests-kerberos", "kerberos", "tenacity"]
 
 extras_require = {"reST": ["Sphinx"]}
 
@@ -70,6 +68,7 @@ setup(
     author_email="jluza@redhat.com",
     url="https://github.com/release-engineering/iiblib",
     classifiers=classifiers,
+    python_requires=">=3.6",
     packages=["iiblib"],
     data_files=[],
     install_requires=INSTALL_REQUIRES,

--- a/tests/test_iib_build_details_model.py
+++ b/tests/test_iib_build_details_model.py
@@ -196,7 +196,6 @@ def test_from_dict_success(
     fixture_optional_args_missing_json,
     fixture_merge_index_image_build_details_json,
 ):
-
     model1 = IIBBuildDetailsModel.from_dict(fixture_add_build_details_json)
     assert model1 == AddModel(**fixture_add_build_details_json)
 
@@ -227,7 +226,6 @@ def test_from_dict_failure(
     fixture_bundle_image_missing_json,
     fixture_unknown_request_type_json,
 ):
-
     key_error_msg = "Unsupported request type: unknown"
     type_error_msg = "Class AddModel doesn't accept rm request type"
 
@@ -304,7 +302,6 @@ def test_from_dict_failure(
 
 
 def test_to_dict_rm(fixture_rm_build_details_json):
-
     rm_model = RmModel(
         id=2,
         arches=["x86_64"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 envlist =
-    py27,
     py37,
-    pycodestyle
-    coverage
-    docs,
+    pycodestyle,
+    coverage,
+    docs
 
 [testenv]
 commands =
@@ -23,12 +22,6 @@ deps=
 show-source=True
 statistics=True
 exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,setup.py,docs
-
-[testenv:py27]
-deps=
-    {[py]deps}
-basepython = python2.7
-commands = python -m pytest -vv --cov=iiblib --cov-report=xml
 
 [testenv:py37]
 deps=


### PR DESCRIPTION
After Supercharge Pub 3 was delivered, Python 2 support is no longer required in it's dependencies as well. Dropping Python 2 will make the repos easier to maintain and will speed up Tox and Github Actions since some steps can be removed.