### PR TITLE
Release 7.2.0

### DIFF
--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 7.2.0 - 2023-09-12
+
+### Added
+ - Added check-related-images parameter to Add request
+
 ## 7.1.0 - 2023-05-18
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ if os.environ.get("READTHEDOCS", None):
 
 setup(
     name="iiblib",
-    version="7.1.0",
+    version="7.2.0",
     description="IIB client library",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Related to: [CLOUDDST-19725](https://issues.redhat.com/browse/CLOUDDST-19725)

 - pubtools-iib fails to use check-related-images flag, because iiblib is not able to use that parameter. Therefore iiblib needs to be released first, then pubtools-iib can be released.