### PR TITLE
Remove retries based on specific state_reason

### DIFF
--- a/iiblib/iib_client.py
+++ b/iiblib/iib_client.py
@@ -10,23 +10,12 @@ from .iib_build_details_model import (
 )
 from .iib_authentication import IIBAuth
 from .iib_session import IIBSession
-from tenacity import retry, stop_after_attempt, retry_if_exception_type
 
 
 class IIBException(Exception):
     """General IIB exception"""
 
     pass
-
-
-class IIBRecoverableError(Exception):
-    """IIB exception raised when we want to retry request"""
-
-    pass
-
-
-# number of retries of failed request
-STATE_REASON_RETRY = 1
 
 
 # pylint: disable=bad-option-value,useless-object-inheritance
@@ -78,7 +67,6 @@ class IIBClient(object):
 
         Raises:
             IIBException when any error occurs
-            IIBRecoverableError when we want to resent request
         """
         if response.status_code >= 400:
             try:
@@ -94,24 +82,6 @@ class IIBClient(object):
             # does not contain valid json
             response.raise_for_status()
 
-        elif response.status_code == 200:
-            try:
-                resp_state_reason = response.json().get("state_reason", "")
-                # retry only request failed for certain state_reason
-                retry_reasons = [
-                    "The connection failed when updating the request",
-                    "Failed to build the container image on the arch",
-                ]
-                for reason in retry_reasons:
-                    if resp_state_reason.startswith(reason):
-                        raise IIBRecoverableError(resp_state_reason)
-            except ValueError:
-                pass
-
-    @retry(
-        retry=retry_if_exception_type(IIBRecoverableError),
-        stop=stop_after_attempt(STATE_REASON_RETRY),
-    )
     def add_bundles(
         self,
         index_image,
@@ -215,10 +185,6 @@ class IIBClient(object):
             return resp.json()
         return AddModel.from_dict(resp.json())
 
-    @retry(
-        retry=retry_if_exception_type(IIBRecoverableError),
-        stop=stop_after_attempt(STATE_REASON_RETRY),
-    )
     def remove_operators(
         self,
         index_image,
@@ -358,10 +324,6 @@ class IIBClient(object):
                 )
             time.sleep(self.poll_interval)
 
-    @retry(
-        retry=retry_if_exception_type(IIBRecoverableError),
-        stop=stop_after_attempt(STATE_REASON_RETRY),
-    )
     def regenerate_bundle(
         self,
         bundle_image,
@@ -399,10 +361,6 @@ class IIBClient(object):
             return resp.json()
         return RegenerateBundleModel.from_dict(resp.json())
 
-    @retry(
-        retry=retry_if_exception_type(IIBRecoverableError),
-        stop=stop_after_attempt(STATE_REASON_RETRY),
-    )
     def create_empty_index(
         self, index_image, binary_image=None, labels=None, raw=False
     ):

--- a/tests/test_iib_client.py
+++ b/tests/test_iib_client.py
@@ -20,41 +20,6 @@ from iiblib.iib_build_details_pager import IIBBuildDetailsPager
 
 
 @pytest.fixture
-def fixture_add_build_details_json_failed():
-    json = {
-        "id": 1,
-        "arches": ["x86_64"],
-        "state": "failed",
-        "state_reason": "The connection failed when updating the request",
-        "request_type": "add",
-        "state_history": [],
-        "batch": 1,
-        "batch_annotations": {"batch_annotations": 1},
-        "build_tags": [],
-        "check_related_images": True,
-        "logs": {},
-        "updated": "updated",
-        "user": "user@example.com",
-        "binary_image": "binary_image",
-        "binary_image_resolved": "binary_image_resolved",
-        "bundles": ["bundles1"],
-        "bundle_mapping": {"bundle_mapping": "map"},
-        "from_index": "from_index",
-        "from_index_resolved": "from_index_resolved",
-        "index_image": "index_image",
-        "index_image_resolved": "index_image_resolved",
-        "internal_index_image_copy": "internal_index_image_copy",
-        "internal_index_image_copy_resolved": "index_image_copy_resolved",
-        "removed_operators": ["operator1"],
-        "organization": "organization",
-        "omps_operator_version": {"operator": "1.0"},
-        "distribution_scope": "null",
-        "deprecation_list": [],
-    }
-    return json
-
-
-@pytest.fixture
 def fixture_add_build_details_json():
     json = {
         "id": 1,
@@ -487,31 +452,6 @@ def test_iib_client(
             iibc, fixture_builds_page1_json
         )
         assert iibc.get_builds(raw=True) == fixture_builds_page1_json
-
-
-def test_iib_client_state_reason_retries(
-    fixture_add_build_details_json_failed,
-):
-    with requests_mock.Mocker() as m:
-        m.register_uri(
-            "POST",
-            "/api/v1/builds/add",
-            status_code=200,
-            json=fixture_add_build_details_json_failed,
-        )
-
-        iibc = IIBClient("fake-host")
-        with pytest.raises(tenacity.RetryError):
-            iibc.add_bundles(
-                "index-image",
-                ["bundles-map"],
-                [],
-                binary_image="binary",
-                cnr_token="cnr",
-                organization="org",
-            )
-
-            assert m.call_count == 2
 
 
 def test_iib_client_no_overwrite_from_index_or_token(


### PR DESCRIPTION
The retries added in [1] don't work because the retried methods
don't wait for IIB build to finish, which means that they can never
encounter an error state. The blocking method, "wait_for_build" has a
side effect of raising IIBRecoverableError exception if a retriable
error is found. This is undesirable because no exception should be
raised if an IIB build fails.

This commit removes the nonfunctional retries and makes sure that no
unnecessary exception is raised. The retry mechanism will not be
re-implemented anywhere else because the negotiation token cannot be
reused in multiple IIB requests.

[1] https://github.com/release-engineering/iiblib/pull/57

Refers to CLOUDDST-22239